### PR TITLE
Remove aeson instances for extensible-0.4.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix: conflict `aeson` instances
     - remove instances in this package
+- Relax PVP for `http-types-0.4.8`
 
 ### 0.1.0.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+### 0.1.1.0
+
+- Fix: conflict `aeson` instances
+    - remove instances in this package
+
 ### 0.1.0.6
 
 - Fix: test on windows, not work `finally`

--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,7 @@ dependencies:
   - connection >=0.2.7 && <0.3
   - constraints >=0.9.1 && <0.11
   - data-default-class >=0.1.2.0 && <0.2
-  - extensible >=0.4.7.2 && <0.4.8
+  - extensible >=0.4.7.2 && <0.4.9
   - http-api-data >=0.3.5 && <0.3.8
   - http-client >=0.5.5.0 && <0.6
   - http-client-tls >=0.3.3.1 && <0.4

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: rakuten
-version: 0.1.0.6
+version: 0.1.1.0
 synopsis: The Rakuten API in Haskell
 description: See README at <https://github.com/matsubara0507/rakuten#readme>
 maintainer: MATSUBARA Nobutada

--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,7 @@ dependencies:
   - connection >=0.2.7 && <0.3
   - constraints >=0.9.1 && <0.11
   - data-default-class >=0.1.2.0 && <0.2
-  - extensible >=0.4.1 && <0.4.7.2
+  - extensible >=0.4.7.2 && <0.4.8
   - http-api-data >=0.3.5 && <0.3.8
   - http-client >=0.5.5.0 && <0.6
   - http-client-tls >=0.3.3.1 && <0.4
@@ -26,7 +26,6 @@ dependencies:
   - lens >=4.15.3 && <5.0
   - req >=0.3.0 && <1.1.0
   - text >=1.2.2.1 && <1.3
-  - unordered-containers >=0.2.8 && <0.3
 
 library:
   source-dirs: src

--- a/rakuten.cabal
+++ b/rakuten.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4c66e879fbf9d4b953c523b0a460bbd3f5515f159b02f3c6e08848c33a205fad
+-- hash: 9002dde5a6bad3413d1de801e57ccffc24926633193cd491521869ecae05d78d
 
 name:           rakuten
 version:        0.1.0.6
@@ -34,7 +34,7 @@ library
     , connection >=0.2.7 && <0.3
     , constraints >=0.9.1 && <0.11
     , data-default-class >=0.1.2.0 && <0.2
-    , extensible >=0.4.1 && <0.4.7.2
+    , extensible >=0.4.7.2 && <0.4.8
     , http-api-data >=0.3.5 && <0.3.8
     , http-client >=0.5.5.0 && <0.6
     , http-client-tls >=0.3.3.1 && <0.4
@@ -42,7 +42,6 @@ library
     , lens >=4.15.3 && <5.0
     , req >=0.3.0 && <1.1.0
     , text >=1.2.2.1 && <1.3
-    , unordered-containers >=0.2.8 && <0.3
   exposed-modules:
       Rakuten
       Rakuten.Client
@@ -71,7 +70,7 @@ test-suite spec
     , connection >=0.2.7 && <0.3
     , constraints >=0.9.1 && <0.11
     , data-default-class >=0.1.2.0 && <0.2
-    , extensible >=0.4.1 && <0.4.7.2
+    , extensible >=0.4.7.2 && <0.4.8
     , hspec >=2.4.1 && <2.5
     , http-api-data >=0.3.5 && <0.3.8
     , http-client >=0.5.5.0 && <0.6
@@ -81,7 +80,6 @@ test-suite spec
     , req >=0.3.0 && <1.1.0
     , servant-server >=0.9.1.1 && <0.14
     , text >=1.2.2.1 && <1.3
-    , unordered-containers >=0.2.8 && <0.3
     , warp >=3.2.11 && <3.3
   other-modules:
       Rakuten.Endpoints.IchibaSpec

--- a/rakuten.cabal
+++ b/rakuten.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 60bd066a61e173b83e33c4957b02fec1e1478d07eb1c38eb311afbcfb03d5a29
+-- hash: 556528d064276649ad99805bc4b9cbd3476bd530ad8b1b0ced4efaca208bb0cd
 
 name:           rakuten
 version:        0.1.1.0
@@ -34,7 +34,7 @@ library
     , connection >=0.2.7 && <0.3
     , constraints >=0.9.1 && <0.11
     , data-default-class >=0.1.2.0 && <0.2
-    , extensible >=0.4.7.2 && <0.4.8
+    , extensible >=0.4.7.2 && <0.4.9
     , http-api-data >=0.3.5 && <0.3.8
     , http-client >=0.5.5.0 && <0.6
     , http-client-tls >=0.3.3.1 && <0.4
@@ -70,7 +70,7 @@ test-suite spec
     , connection >=0.2.7 && <0.3
     , constraints >=0.9.1 && <0.11
     , data-default-class >=0.1.2.0 && <0.2
-    , extensible >=0.4.7.2 && <0.4.8
+    , extensible >=0.4.7.2 && <0.4.9
     , hspec >=2.4.1 && <2.5
     , http-api-data >=0.3.5 && <0.3.8
     , http-client >=0.5.5.0 && <0.6

--- a/rakuten.cabal
+++ b/rakuten.cabal
@@ -2,10 +2,10 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9002dde5a6bad3413d1de801e57ccffc24926633193cd491521869ecae05d78d
+-- hash: 60bd066a61e173b83e33c4957b02fec1e1478d07eb1c38eb311afbcfb03d5a29
 
 name:           rakuten
-version:        0.1.0.6
+version:        0.1.1.0
 synopsis:       The Rakuten API in Haskell
 description:    See README at <https://github.com/matsubara0507/rakuten#readme>
 category:       Web

--- a/src/Rakuten/Types/Class.hs
+++ b/src/Rakuten/Types/Class.hs
@@ -12,33 +12,17 @@ module Rakuten.Types.Class
     ) where
 
 import           Control.Applicative   (liftA2)
-import           Data.Aeson            hiding (KeyValue)
 import           Data.Bool             (bool)
 import           Data.Constraint
 import           Data.Default.Class    (Default (..))
 import           Data.Extensible
 import           Data.Functor.Identity (Identity (..))
-import qualified Data.HashMap.Strict   as HM
 import           Data.Monoid           (Endo (..), (<>))
 import           Data.Proxy
 import           Data.String           (fromString)
 import           Data.Text             (Text)
 import           GHC.TypeLits          (KnownSymbol, symbolVal)
 import           Network.HTTP.Req      (QueryParam, (=:))
-
-instance Forall (KeyValue KnownSymbol FromJSON) xs => FromJSON (Record xs) where
-  parseJSON = withObject "Object" $
-    \v -> hgenerateFor (Proxy :: Proxy (KeyValue KnownSymbol FromJSON)) $
-    \m -> let k = symbolVal (proxyAssocKey m) in
-      case HM.lookup (fromString k) v of
-        Just a  -> Field . return <$> parseJSON a
-        Nothing -> fail $ "Missing key: " `mappend` k
-
-instance Forall (KeyValue KnownSymbol ToJSON) xs => ToJSON (Record xs) where
-  toJSON = Object . HM.fromList . flip appEndo [] . hfoldMap getConst' . hzipWith
-    (\(Comp Dict) -> Const' . Endo . (:) .
-      liftA2 (,) (fromString . symbolVal . proxyAssocKey) (toJSON . getField))
-    (library :: Comp Dict (KeyValue KnownSymbol ToJSON) :* xs)
 
 instance Default a => Default (Identity a) where
   def = Identity def

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,8 +3,8 @@ resolver: nightly-2018-03-06
 packages:
 - .
 
-extra-deps: []
-# - extensile-0.4.7.2
+extra-deps: # []
+- extensible-0.4.7.2
 # - servant-0.13
 # - servant-server-0.13
 # - http-types-0.12

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 
 extra-deps: # []
-- extensible-0.4.7.2
+- extensible-0.4.8
 # - servant-0.13
 # - servant-server-0.13
 # - http-types-0.12


### PR DESCRIPTION
see: https://github.com/fpco/stackage/issues/3334

This failure is conflict `ToJSON` and `FromJSON` type class instances for extensible record.
This instances are defined in `rakuten` package, but defined in `extensible` from [v0.4.7.2](https://github.com/fumieval/extensible/commit/61983af4e07441d8de8a017c303ab5e3f8848ebf).